### PR TITLE
hotfix

### DIFF
--- a/gui/repositoriesview.go
+++ b/gui/repositoriesview.go
@@ -250,6 +250,9 @@ func (gui *Gui) submitCredentials(g *gocui.Gui, v *gocui.View) error {
 func (gui *Gui) markRepository(g *gocui.Gui, v *gocui.View) error {
 	r := gui.getSelectedRepository()
 	// maybe, failed entities may be added to queue again
+	if r == nil {
+		return nil
+	}
 	if r.WorkStatus().Ready {
 		if err := gui.addToQueue(r); err != nil {
 			return err


### PR DESCRIPTION
I found another issue when enter space immediately after startup and following exception occurs. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8 pc=0x146ba24]

goroutine 1 [running]:
github.com/isacikgoz/gitbatch/core/git.(*Repository).WorkStatus(...)
	/home/isacikgoz/.local/share/go/src/github.com/isacikgoz/gitbatch/core/git/repository.go:221
github.com/isacikgoz/gitbatch/gui.(*Gui).markRepository(0xc42016ef00, 0xc420206000, 0xc42023a0f0, 0xc420208060, 0xc420208000)
	/home/isacikgoz/.local/share/go/src/github.com/isacikgoz/gitbatch/gui/repositoriesview.go:253 +0x34
github.com/isacikgoz/gitbatch/gui.(*Gui).(github.com/isacikgoz/gitbatch/gui.markRepository)-fm(0xc420206000, 0xc42023a0f0, 0x4, 0xc4200efb01)
	/home/isacikgoz/.local/share/go/src/github.com/isacikgoz/gitbatch/gui/keybindings.go:295 +0x3e
github.com/jroimartin/gocui.(*Gui).execKeybindings(0xc420206000, 0xc42023a0f0, 0xc4200efb48, 0x1450b69, 0x0, 0x0)
	/home/isacikgoz/.local/share/go/src/github.com/jroimartin/gocui/gui.go:629 +0xce
github.com/jroimartin/gocui.(*Gui).onKey(0xc420206000, 0xc4200efb48, 0xc42021aa80, 0xc42020e010)
	/home/isacikgoz/.local/share/go/src/github.com/jroimartin/gocui/gui.go:593 +0x1b3
github.com/jroimartin/gocui.(*Gui).handleEvent(0xc420206000, 0xc4200efb48, 0xc4200efb40, 0x0)
	/home/isacikgoz/.local/share/go/src/github.com/jroimartin/gocui/gui.go:413 +0x40
github.com/jroimartin/gocui.(*Gui).MainLoop(0xc420206000, 0xc420206000, 0x0)
	/home/isacikgoz/.local/share/go/src/github.com/jroimartin/gocui/gui.go:373 +0x2cf
github.com/isacikgoz/gitbatch/gui.(*Gui).Run(0xc42016ef00, 0x0, 0x0)
	/home/isacikgoz/.local/share/go/src/github.com/isacikgoz/gitbatch/gui/gui.go:140 +0x1ee
main.run(0x0, 0x0, 0x0, 0x170b753, 0x5, 0x0, 0x169fe00, 0x0, 0x0, 0x0, ...)
	/home/isacikgoz/git/gitbatch/main.go:52 +0x122
main.main()
	/home/isacikgoz/git/gitbatch/main.go:24 +0xc2
```
This time I came with my solution :)