### PR TITLE
Added support for linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: go
 go:
   - "1.14"
   - tip
-
+arch:
+  - amd64
+  - ppc64le
 before_install:
   - go get -t -v ./...
 


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/gitbatch/builds/187454746

Please have a look.

Regards,
ujjwal