### PR TITLE
Add goreleaser with homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*.*.*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code into $GITHUB_WORKSPACE directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.3
+      id: go
+
+    - name: GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,24 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+builds:
+-
+  # Path to main.go file or main package. Default is `.`.
+  main: ./cmd/gitbatch/main.go
+  env:
+  - CGO_ENABLED=0
+    # GOOS list to build for. Defaults are darwin and linux.
+    # For more info: https://golang.org/doc/install/source#environment
+  goos:
+  - darwin
+  - linux
+  - windows
+
+brews:
+  -
+    tap:
+      owner: isacikgoz
+      name: homebrew-taps
+    homepage: "{{ .GitURL }}"
+    description: Manage your git repositories in one place


### PR DESCRIPTION
It's necessary to add a secret named `HOMEBREW_TAP` to access the repository `isacikgoz/homebrew-taps`.

issue: close #109